### PR TITLE
Add tagging capabilities

### DIFF
--- a/static-site/main.tf
+++ b/static-site/main.tf
@@ -8,6 +8,11 @@ resource "aws_s3_bucket" "site" {
     index_document = "index.html"
     error_document = "${var.error_document}"
   }
+
+  tags = "${merge(var.tags, map(
+    "Name", "${var.domain_name}"
+))}"
+
 }
 
 // IAM


### PR DESCRIPTION
This PR adds tagging capabilities to the static site module. Upon later instantiation of the module, it comes with the `Name` tag, which is equal the domain name being used, which also matches the S3 Bucket name.